### PR TITLE
[NGC-4676] Render LocalDates and LocalDateTimes as Longs in json output 

### DIFF
--- a/app/uk/gov/hmrc/mobiletaxcreditssummary/domain/userdata/Child.scala
+++ b/app/uk/gov/hmrc/mobiletaxcreditssummary/domain/userdata/Child.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.mobiletaxcreditssummary.domain.userdata
 
 import java.time.temporal.ChronoUnit
-import java.time.{LocalDate, LocalDateTime, Period}
+import java.time.{LocalDate, Period}
 
 import play.api.libs.json.{Json, OFormat}
 

--- a/app/uk/gov/hmrc/mobiletaxcreditssummary/domain/userdata/Claimants.scala
+++ b/app/uk/gov/hmrc/mobiletaxcreditssummary/domain/userdata/Claimants.scala
@@ -18,11 +18,8 @@ package uk.gov.hmrc.mobiletaxcreditssummary.domain.userdata
 
 import play.api.libs.json.{Json, OFormat}
 
-case class Claimants(personalDetails: Person,
-                     partnerDetails: Option[Person],
-                     children: Seq[Person])
+case class Claimants(personalDetails: Person, partnerDetails: Option[Person], children: Seq[Person])
 
 object Claimants {
   implicit val format: OFormat[Claimants] = Json.format[Claimants]
 }
-

--- a/app/uk/gov/hmrc/mobiletaxcreditssummary/domain/userdata/package.scala
+++ b/app/uk/gov/hmrc/mobiletaxcreditssummary/domain/userdata/package.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobiletaxcreditssummary.domain
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+
+import play.api.libs.json.Reads.{DefaultLocalDateReads, DefaultLocalDateTimeReads}
+import play.api.libs.json._
+
+package object userdata {
+
+  /**
+    * We want `LocalDate`s and `LocalDateTime`s returned via the api to be rendered as `Longs`.
+    * Play's default is to render as a formatted string, but by supplying these `Writes` and `Format`
+    * instances in the package they will be picked up in preference to the defaults.
+    */
+  implicit val localDateTimeWrites: Writes[LocalDateTime] = new Writes[LocalDateTime] {
+    override def writes(o: LocalDateTime): JsValue =
+      JsNumber(o.toInstant(ZoneOffset.UTC).toEpochMilli)
+  }
+
+  implicit val LocalDateTimeFormat: Format[LocalDateTime] = new Format[LocalDateTime] {
+    override def writes(o: LocalDateTime): JsValue =
+      localDateTimeWrites.writes(o)
+
+    override def reads(json: JsValue): JsResult[LocalDateTime] =
+      DefaultLocalDateTimeReads.reads(json)
+  }
+
+  implicit val localDateWrites: Writes[LocalDate] = new Writes[LocalDate] {
+    override def writes(o: LocalDate): JsValue =
+      JsNumber(o.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli)
+  }
+
+  implicit val LocalDateFormat: Format[LocalDate] = new Format[LocalDate] {
+    override def writes(o: LocalDate): JsValue =
+      localDateWrites.writes(o)
+
+    override def reads(json: JsValue): JsResult[LocalDate] =
+      DefaultLocalDateReads.reads(json)
+  }
+}

--- a/test/uk/gov/hmrc/mobiletaxcreditssummary/domain/ChildSpec.scala
+++ b/test/uk/gov/hmrc/mobiletaxcreditssummary/domain/ChildSpec.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.mobiletaxcreditssummary.domain
 import java.time.LocalDate
 
 import org.scalatest.{Matchers, WordSpecLike}
+import play.api.libs.json.Json
 import uk.gov.hmrc.mobiletaxcreditssummary.domain.userdata.Child
 
 class ChildSpec extends WordSpecLike with Matchers {
 
   "Child DOB calculation" should {
-
     "using today's date for child DOB will result in age 0" in {
       val childA = Child("first", "second", LocalDate.now, hasFTNAE = false, hasConnexions = false, isActive = false, None)
 
@@ -43,6 +43,13 @@ class ChildSpec extends WordSpecLike with Matchers {
 
       Child.getAge(childC) shouldBe 15
     }
+  }
 
+  "Converting Child to json" should {
+    "render the birth date as a Long" in {
+      val expected = Json.parse("""{"firstNames":"","surname":"","dateOfBirth":1546300800000,"hasFTNAE":false,"hasConnexions":false,"isActive":false}""")
+      val child    = Child("", "", LocalDate.parse("2019-01-01"), hasFTNAE = false, hasConnexions = false, isActive = false, None)
+      jsonDiff(None, Json.toJson(child), expected) shouldBe 'empty
+    }
   }
 }

--- a/test/uk/gov/hmrc/mobiletaxcreditssummary/domain/package.scala
+++ b/test/uk/gov/hmrc/mobiletaxcreditssummary/domain/package.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobiletaxcreditssummary
+import play.api.libs.json.{JsArray, JsNull, JsObject, JsValue}
+
+package object domain {
+
+  /**
+    * Handy function to calculate the diffs between two json objects and return a list of messages.
+    */
+  def jsonDiff(name: Option[String], j1: JsValue, j2: JsValue): List[String] = {
+    def nam(n: String, io: Option[Int]): Some[String] =
+      (name, io) match {
+        case (None, None)        => Some(n)
+        case (None, Some(i))     => Some(s"$n[$i]")
+        case (Some(n1), None)    => Some(s"$n1.$n")
+        case (Some(n1), Some(i)) => Some(s"$n1.$n[$i]")
+      }
+
+    j1 match {
+      case _ if j1.getClass != j2.getClass => List(s"Types of ${name.getOrElse("")} differ - $j1 vs. $j2")
+      case o: JsObject =>
+        o.fields.flatMap {
+          case (n, v) => jsonDiff(nam(n, None), v, (j2 \ n).getOrElse(JsNull))
+        }.toList
+
+      case JsArray(vs) =>
+        val vs2 = j2.as[JsArray].value
+        val lengthCheck =
+          if (vs.length != vs2.length) List(s"${name.getOrElse("")}: Array 1 has length ${vs.length} but array 2 has length ${vs2.length}")
+          else List()
+        lengthCheck ++
+          vs.zipWithIndex.flatMap {
+            case (v, i) =>
+              vs2.drop(i).headOption match {
+                case Some(v2) => jsonDiff(nam(name.getOrElse(""), Some(i)), v, v2)
+                case None     => List()
+              }
+          }
+
+      case _ if j1 == j2 => List()
+      case _             => List(s"Values of ${name.getOrElse("")} differ - '$j1' vs. '$j2'")
+    }
+  }
+}


### PR DESCRIPTION
I've added specialised Json Writes instances for LocalDate and LocalDateTime that will override Play's defaults and render them as Longs rather than formatted Strings.

As part of the testing I've written a (rather crude) function to compare two json values and return a list of diffs, which are a little easier to look at in the test output than two big blobs of json text.